### PR TITLE
Disable empty tempo and rounds input

### DIFF
--- a/app/badminton/six-point/page.tsx
+++ b/app/badminton/six-point/page.tsx
@@ -44,8 +44,8 @@ export default function SixPointFootwork() {
   };
 
   const startReader = () => {
-    if (tempo <= 0) return alert("Tempo must be > 0");
-    if (maxRounds <= 0) return alert("Rounds must be > 0");
+    if (!tempo || tempo <= 0) return alert("Tempo must be > 0");
+    if (!maxRounds || maxRounds <= 0) return alert("Rounds must be > 0");
 
     currentRoundRef.current = 0;
     setIsRunning(true);


### PR DESCRIPTION
Do not start the reader if the input of tempo
or max rounds is empty. Otherwise, it
introduces undefined behaviors.

Closes #4 